### PR TITLE
🧮User Statistics

### DIFF
--- a/libs/amplify/amplify/backend/api/reversehandapi/schema.graphql
+++ b/libs/amplify/amplify/backend/api/reversehandapi/schema.graphql
@@ -23,6 +23,9 @@ type Query {
 
   getNotifications(user_id: String!): [Notification!]!
   @function(name: "getNotificationsResolver-${env}")
+
+  getUserStatistics(user_id: String!): Statistics!
+  @function(name: "getUserStatisticsResolver-${env}")
 }
 
 type Mutation {
@@ -136,6 +139,23 @@ type User implements UniqueID {
   reviews: [Review!]
   sum: Int, #For the time being nullable but will be changed once things like create user initialize this to zero
   advertsWon: [String] 
+}
+
+type Statistics {
+  rating_sum: Int!,
+  num_reviews: Int!,
+  consumer_stats: ConsumerStats!,
+  tradesman_stats: TradesmanStats!
+}
+
+type ConsumerStats{
+  num_adverts_won: Int!,
+  num_adverts_created: Int!
+}
+
+type TradesmanStats{
+  num_jobs_won: Int!,
+  num_bids_placed: Int!
 }
 
 type Chat {

--- a/libs/amplify/amplify/backend/function/acceptBidResolver/acceptBidResolver-cloudformation-template.json
+++ b/libs/amplify/amplify/backend/function/acceptBidResolver/acceptBidResolver-cloudformation-template.json
@@ -73,7 +73,8 @@
             "REGION": {
               "Ref": "AWS::Region"
             },
-            "REVERSEHAND": "ReverseHand"
+            "REVERSEHAND": "ReverseHand",
+            "USER": "User"
           }
         },
         "Role": {
@@ -193,7 +194,8 @@
                 "dynamodb:Query",
                 "dynamodb:Scan",
                 "dynamodb:Delete*",
-                "dynamodb:UpdateItem"
+                "dynamodb:UpdateItem",
+                "dynamodb:GetItem"
               ],
               "Resource": [
                 {
@@ -209,6 +211,14 @@
                     "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}/index/*",
                     {
                       "tablename": "ReverseHand"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}",
+                    {
+                      "tablename": "User"
                     }
                   ]
                 }

--- a/libs/amplify/amplify/backend/function/getUserStatisticsResolver/src/index.js
+++ b/libs/amplify/amplify/backend/function/getUserStatisticsResolver/src/index.js
@@ -26,11 +26,11 @@ exports.handler = async (event) => {
         let reviews = data['Item']['reviews'];
 
         //consumer variables
-        let numAdvertsCreated = "";//number of adverts that a consumer created
+        let numAdvertsCreated = 0;//number of adverts that a consumer created
         let numAdvertsWon = 0; //adverts which got completed by a tradesman
 
         //tradesman variables
-        let numBidsCreated = "";
+        let numBidsCreated = 0;
         let numJobsWon = 0;
         
         
@@ -55,7 +55,7 @@ exports.handler = async (event) => {
                     numAdvertsWon += 1;
             });
 
-            numAdvertsWon = numAdvertsWon;//.toString();//convert the int to a string
+            
         }
         else //data which is specific to a tradesman
         {
@@ -72,24 +72,29 @@ exports.handler = async (event) => {
                 }
             };
 
-            data = await docClient.query(params).promise();
+            let Tdata = await docClient.query(params).promise();
 
-            numBidsCreated = data['Count'];
-            console.log(numBidsCreated);
-
-            (data['Items']).forEach(bid => {
-                console.log(bid);
-            });
+            numBidsCreated = Tdata['Count'];
 
             //Need to get bids won by the tradesman
+            numJobsWon = (data['Item']['adverts_won']).length;
         }
 
         let result = {
             rating_sum : ratingSum,
-            num_review : (reviews.length).toString()
+            num_reviews : reviews.length,
+            consumer_stats : {
+                num_adverts_won : numAdvertsWon,
+                num_adverts_created : numAdvertsCreated
+            },
+            tradesman_stats : {
+                num_jobs_won : numJobsWon,
+                num_bids_placed: numBidsCreated
+            }
         };
 
-        console.log(result);
+        
+        return result;
 
         
     } catch (error) {

--- a/libs/amplify/amplify/backend/function/shortListBidResolver/src/index.js
+++ b/libs/amplify/amplify/backend/function/shortListBidResolver/src/index.js
@@ -38,9 +38,9 @@ exports.handler = async (event) => {
             Item: {
                 part_key: event.arguments.ad_id,
                 sort_key: shortBidId, // prefixing but keeping same suffix
+                tradesman_id: bid['tradesman_id'],
                 bid_details: {
                     id: shortBidId,
-                    tradesman_id: bid['bid_details']['tradesman_id'],
                     name: bid['bid_details']['name'],
                     price_lower: bid['bid_details']['price_lower'],
                     price_upper: bid['bid_details']['price_upper'],

--- a/libs/amplify/amplify/backend/function/shortListBidResolver/src/index.js
+++ b/libs/amplify/amplify/backend/function/shortListBidResolver/src/index.js
@@ -38,9 +38,9 @@ exports.handler = async (event) => {
             Item: {
                 part_key: event.arguments.ad_id,
                 sort_key: shortBidId, // prefixing but keeping same suffix
-                tradesman_id: bid['tradesman_id'],
                 bid_details: {
                     id: shortBidId,
+                    tradesman_id: bid['tradesman_id'],
                     name: bid['bid_details']['name'],
                     price_lower: bid['bid_details']['price_lower'],
                     price_upper: bid['bid_details']['price_upper'],

--- a/libs/amplify/amplify/team-provider-info.json
+++ b/libs/amplify/amplify/team-provider-info.json
@@ -56,7 +56,7 @@
         },
         "shortListBidResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/shortListBidResolver-3030664f6a5462424644-build.zip"
+          "s3Key": "amplify-builds/shortListBidResolver-64723543584d514a3239-build.zip"
         },
         "viewAdvertsResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
@@ -80,7 +80,7 @@
         },
         "createUserResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/createUserResolver-6e754648666744634475-build.zip"
+          "s3Key": "amplify-builds/createUserResolver-3137587376654c706e71-build.zip"
         },
         "deleteAdvertResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
@@ -144,7 +144,7 @@
         },
         "getUserStatisticsResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/getUserStatisticsResolver-665052664c4458743079-build.zip"
+          "s3Key": "amplify-builds/getUserStatisticsResolver-663133624b346a467149-build.zip"
         }
       }
     }

--- a/libs/amplify/amplify/team-provider-info.json
+++ b/libs/amplify/amplify/team-provider-info.json
@@ -40,7 +40,7 @@
       "function": {
         "acceptBidResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/acceptBidResolver-716e574645392b4b5755-build.zip"
+          "s3Key": "amplify-builds/acceptBidResolver-436e4f396b6d356a4770-build.zip"
         },
         "closeAdvertResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
@@ -56,7 +56,7 @@
         },
         "shortListBidResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/shortListBidResolver-64723543584d514a3239-build.zip"
+          "s3Key": "amplify-builds/shortListBidResolver-696e5a68595179325154-build.zip"
         },
         "viewAdvertsResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
@@ -144,7 +144,7 @@
         },
         "getUserStatisticsResolver": {
           "deploymentBucketName": "amplify-reversehand-staging-100406-deployment",
-          "s3Key": "amplify-builds/getUserStatisticsResolver-663133624b346a467149-build.zip"
+          "s3Key": "amplify-builds/getUserStatisticsResolver-2f3270534c4931565772-build.zip"
         }
       }
     }


### PR DESCRIPTION
- Modified AcceptBidResolver to store ad_id in one of the tradesman attributes
- ``` {
  "data": {
    "getUserStatistics": {
      "consumer_stats": {
        "num_adverts_won": 0,
        "num_adverts_created": 1
      },
      "tradesman_stats": {
        "num_jobs_won": 0,
        "num_bids_placed": 0
      },
      "rating_sum": 3,
      "num_reviews": 1
    }
  }

- Above is example response for a consumer
- Linked the resolver to AppSync
